### PR TITLE
Add importlib-metadata temporarily to fix pip check.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - folium
     - gdal >=2.1.0
     - geojson
+    - importlib-metadata  # [py37] # undefined upstream requirement (see https://github.com/conda-forge/filesystem-spec-feedstock/pull/43)
     - matplotlib-base
     - numpy
     - pandas


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Temporarily added importlib-metadata (undefined in fsspec 0.9.0) to fix `pip check` in https://github.com/conda-forge/geoarray-feedstock/pull/26 and https://github.com/conda-forge/geoarray-feedstock/pull/27. As soon as https://github.com/conda-forge/filesystem-spec-feedstock/pull/43 is solved, this can be removed.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
